### PR TITLE
feat(rules): add rule for react hooks rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "plugins": [
       "jsx-a11y",
       "import",
-      "unicorn"
+      "unicorn",
+      "react-hooks"
     ],
     "rules": {
       "jsx-quotes": [
@@ -97,7 +98,9 @@
         {
           "case": "kebabCase"
         }
-      ]
+      ],
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn"
     },
     "settings": {
       "import/resolver": {

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog"
         }
+    },
+    "devDependencies": {
+        "eslint-plugin-react-hooks": "^1.6.0"
     }
 }


### PR DESCRIPTION
There are 2 very important rules when it comes to hooks:

1. Only call them from the top level.
2. Only call them in functional components.

More info: https://reactjs.org/docs/hooks-rules.html

This update checks to see that our code meets these two rules. 